### PR TITLE
Update eos.cpp (remove reference to nan_isolate)

### DIFF
--- a/src/eos.cpp
+++ b/src/eos.cpp
@@ -339,7 +339,7 @@ namespace Eos {
 
     void PrintStackTrace() {
         PrintStackTrace(
-            IF_NODE_12( StackTrace::CurrentStackTrace(nan_isolate, 10)
+            IF_NODE_12( StackTrace::CurrentStackTrace(v8::Isolate::GetCurrent(), 10)
                       , StackTrace::CurrentStackTrace(10)));
     }
 


### PR DESCRIPTION
Hi
Platform Win7, msvc12.
compiler error : nan_isolate not defined.
